### PR TITLE
docs: add Video Prompt Lab to tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -900,6 +900,7 @@ The infrastructure layer that wraps an LLM: tool access, lifecycle management, p
 | [LM Evaluation Harness](https://github.com/EleutherAI/lm-evaluation-harness) | EleutherAI's unified LLM evaluation framework |
 | [Weights & Biases](https://wandb.ai/site/solutions/llmops) | Experiment tracking and LLMOps |
 | [Promptingguide.ai](https://www.promptingguide.ai/) | Comprehensive prompt engineering reference (DAIR-AI) |
+| [Video Prompt Lab](https://github.com/YYH123123813/video-prompt-lab) | Local-first AI-video prompt workflow — one ShotSpec YAML generates model-specific prompts for Sora, Veo, Runway, Kling, and Seedance, then adds lint reports and eval scorecards |
 | [awesome-ai-agents-2026](https://github.com/caramaschiHG/awesome-ai-agents-2026) | Most comprehensive list of 2026 AI agents, frameworks & tools — 300+ resources, 20+ categories, updated monthly ![](https://img.shields.io/github/stars/caramaschiHG/awesome-ai-agents-2026?style=flat-square) |
 | [Awesome-Agent-Papers](https://github.com/luo-junyu/Awesome-Agent-Papers) | Curated papers on LLM agents: methodology, applications, challenges — covers STRIDE, planning, tool use, memory, multi-agent (2026) ![](https://img.shields.io/github/stars/luo-junyu/Awesome-Agent-Papers?style=flat-square) |
 | [Awesome-Agentic-Reasoning](https://github.com/weitianxin/Awesome-Agentic-Reasoning) | Papers and resources on agentic reasoning from foundational to multi-agent coordination — 3-layer framework (2026) ![](https://img.shields.io/github/stars/weitianxin/Awesome-Agentic-Reasoning?style=flat-square) |


### PR DESCRIPTION
## Summary

- adds Video Prompt Lab to the Tools & Libraries section
- positions it as a local-first AI-video prompt workflow tool
- keeps the description aligned with the repo scope: ShotSpec YAML -> model-specific prompts + lint + eval

## Why it fits

Video Prompt Lab is not a generic prompt dump. It is a prompt-engineering workflow for AI video generation: structured brief, prompt rendering, linting, and evaluation. That makes it a better fit for the repo's engineering-oriented tool list than for the prompt-example tables.