### PR TITLE
Add LLM Token Counter tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -920,6 +920,7 @@ The infrastructure layer that wraps an LLM: tool access, lifecycle management, p
 | [Anthropic Prompt Library](https://docs.anthropic.com/en/prompt-library/library) | Official production-ready prompts from Anthropic |
 | [NirDiamant/Prompt_Engineering](https://github.com/NirDiamant/Prompt_Engineering) | 22 Jupyter Notebook tutorials from basics to advanced — CoT, few-shot, templates, multi-language ![](https://img.shields.io/github/stars/NirDiamant/Prompt_Engineering?style=flat-square) |
 | [automotive-skills-suite](https://github.com/jherrodthomas/automotive-skills-suite) | 152 installable Claude skills for automotive engineering — ISO 26262, ISO/SAE 21434, ISO 21448 SOTIF, AIAG-VDA, ASPICE, AUTOSAR; builder + reviewer pairs with xlsx deliverables ![](https://img.shields.io/github/stars/jherrodthomas/automotive-skills-suite?style=flat-square) |
+| [LLM Token Counter](https://code-two-delta.vercel.app) | Client-side token counter for GPT-4o, Claude, Gemini. No login required, instant cost estimates. |
 
 ---
 


### PR DESCRIPTION
## What's being added

[LLM Token Counter](https://code-two-delta.vercel.app) — a client-side tool that counts tokens and estimates API costs for multiple LLMs simultaneously.

**Features:**
- Supports GPT-4o, GPT-3.5-turbo, Claude 3 Haiku, and Gemini 1.5 Flash
- No login, no backend — runs entirely in the browser
- Instant cost estimates as you type
- Source: https://github.com/SolvoHQ/llm-token-counter

## Where it fits

Added to the **Tools & Libraries** section — this is a lightweight, no-install web tool for developers who want to estimate token counts and costs before making API calls. Useful alongside any prompt engineering workflow.