### PR TITLE
Add APort to Red Team & Security tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,7 @@ Probe LLM systems for vulnerabilities before attackers do.
 | [**The Promptware Kill Chain**](https://arxiv.org/abs/2601.09625) | — | Bruce Schneier (Harvard/Lawfare): reframes prompt injection as a 7-stage malware kill chain; 21/36 documented attacks already traverse 4+ stages. Featured at Black Hat 2026. | [PDF](https://arxiv.org/pdf/2601.09625) |
 | [**Microsoft Agent Governance Toolkit**](https://github.com/microsoft/agent-governance-toolkit) | ![](https://img.shields.io/github/stars/microsoft/agent-governance-toolkit?style=flat-square) | 7 packages (Python/Rust/TS/Go/.NET) — policy enforcement (<0.1ms), zero-trust agent identity (Ed25519 + SPIFFE), sandboxed execution; covers all OWASP Agentic Top 10; adapters for LangChain/CrewAI/ADK/OpenAI Agents SDK (Apr 2026) |
 | [**agent-drift**](https://github.com/jhammant/agent-drift) | ![](https://img.shields.io/github/stars/jhammant/agent-drift?style=flat-square) | Stress-test agents for goal drift and system-prompt violations across 6 value dimensions — multi-turn escalation, LLM-as-judge, interactive HTML reports; inspired by ICLR 2026 workshop paper (Apr 2026) |
+| [**APort**](https://aport.io) | ![](https://img.shields.io/github/stars/aporthq/aport-integrations?style=flat-square) | Agent identity and policy enforcement for AI-agent tool calls, with [guardrail integration examples](https://github.com/aporthq/aport-integrations) for pre-action authorization. |
 
 ### Eval & Observability
 


### PR DESCRIPTION
Adds APort to the Red Team & Security section.

- Links the APort website
- Includes the guardrail integration examples repository
- Describes the identity and policy enforcement use case for AI-agent tool calls