### PR TITLE
Add Prompt Evaluator — web-based prompt and workflow QA tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,7 @@ Make prompt quality measurable. Regression tests, benchmarks, and CI/CD for LLM 
 | [**promptfoo**](https://github.com/promptfoo/promptfoo) | ![](https://img.shields.io/github/stars/promptfoo/promptfoo?style=flat-square) | Test-driven prompt engineering: regression tests, red teaming, model comparison, CI/CD integration. [Acquired by OpenAI (Mar 2026)](https://openai.com/index/openai-to-acquire-promptfoo/) — remains open source. |
 | [**OpenAI Evals**](https://github.com/openai/evals) | ![](https://img.shields.io/github/stars/openai/evals?style=flat-square) | Open eval framework and benchmark registry — standardizes LLM performance measurement. |
 | [**Terminal-Bench**](https://github.com/laude-institute/terminal-bench) | — | Real-terminal agent benchmark (Stanford/Laude) — compile code, train models, set up servers in Docker-sandboxed environments; the de facto benchmark for agentic coding (2026). |
+| [**Prompt Evaluator**](https://prompt-evaluator-eight.vercel.app) | — | Web-based prompt and workflow QA tool — compare prompts across models, benchmark quality, catch regressions before deployment. Free tier with Pro upgrade. |
 
 ### Red Team & Security
 


### PR DESCRIPTION
## Prompt Evaluator

**Live site:** https://prompt-evaluator-eight.vercel.app

A web-based prompt and workflow QA tool that helps teams compare prompts across models, benchmark quality, and catch regressions before deployment.

**Why it fits the Eval & Testing section:**
- Directly addresses "Make prompt quality measurable" — the section heading
- Complements promptfoo (CI/CD regression testing) with a web-based comparison/benchmark workflow
- Free tier available, Pro upgrade for team use
- Covers the interactive/visual evaluation use case that promptfoo and OpenAI Evals do not

**What it does:**
- Compare the same prompt across multiple LLMs side-by-side
- Benchmark prompt quality with structured scoring rubrics
- Catch prompt regressions before they reach production
- Free tier for individual use, Pro for teams

Placed after Terminal-Bench in the Eval & Testing table, before the Red Team & Security section.