### PR TITLE
Add Prompt Evaluator — web-based prompt and workflow QA tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,7 @@ Make prompt quality measurable. Regression tests, benchmarks, and CI/CD for LLM 
 | [**promptfoo**](https://github.com/promptfoo/promptfoo) | ![](https://img.shields.io/github/stars/promptfoo/promptfoo?style=flat-square) | Test-driven prompt engineering: regression tests, red teaming, model comparison, CI/CD integration. [Acquired by OpenAI (Mar 2026)](https://openai.com/index/openai-to-acquire-promptfoo/) — remains open source. |
 | [**OpenAI Evals**](https://github.com/openai/evals) | ![](https://img.shields.io/github/stars/openai/evals?style=flat-square) | Open eval framework and benchmark registry — standardizes LLM performance measurement. |
 | [**Terminal-Bench**](https://github.com/laude-institute/terminal-bench) | — | Real-terminal agent benchmark (Stanford/Laude) — compile code, train models, set up servers in Docker-sandboxed environments; the de facto benchmark for agentic coding (2026). |
+| [**Prompt Evaluator**](https://prompt-evaluator-eight.vercel.app) | — | Web-based prompt and workflow QA tool — compare prompts across models, benchmark quality, catch regressions before deployment. Free tier with Pro upgrade. |
 
 ### Red Team & Security
 


### PR DESCRIPTION
## Addition

Added **Prompt Evaluator** to the Eval & Testing section.

**What it does:** Web-based prompt and workflow QA tool — compare prompts across models, benchmark quality, catch regressions before deployment. Free tier with Pro upgrade.

**Why it fits:** Fits alongside promptfoo, OpenAI Evals, and Terminal-Bench as an evaluation tool, but uniquely focuses on prompt/workflow auditing for production LLM systems rather than regression testing or benchmarking.

**URL:** https://prompt-evaluator-eight.vercel.app

Placed after Terminal-Bench in the Eval & Testing table. Happy to adjust position or description if needed.