### PR TITLE
Add TWZRD Agent Intel to MCP servers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -654,6 +654,7 @@ Open protocol (Anthropic, Nov 2024) for connecting LLMs to tools and data. Now a
 
 - Spec: [modelcontextprotocol.io](https://modelcontextprotocol.io/specification/2025-11-25)
 - Official servers: [github.com/modelcontextprotocol/servers](https://github.com/modelcontextprotocol/servers)
+- [TWZRD Agent Intel MCP](https://intel.twzrd.xyz): On-chain agent trust scoring — `score_agent`, `preflight_check`, `get_trust_receipt`. HTTP 402 micro-payment gated. Config: `{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}`
 
 ### A2A — Agent-to-Agent Protocol
 


### PR DESCRIPTION
## What this adds

[TWZRD Agent Intel](https://intel.twzrd.xyz) to the **MCP — Model Context Protocol** section.

**Why it belongs here:** TWZRD is a production MCP server (streamable-http) providing on-chain agent trust scoring for Solana agents — a new category of MCP tool that connects agent harnesses to blockchain identity signals.

Tools:
- `score_agent(wallet)` — free on-chain reputation score
- `preflight_check(wallet)` — free deployment safety check
- `get_trust_receipt(wallet)` — HTTP 402 micro-payment gated trust receipt

**MCP config:**
```json
{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}
```

This is the first MCP server in the list that combines blockchain identity verification with the standard MCP tool protocol.