### PR TITLE
Add NotFair to Agent Skills (open-source marketing/SEO/ads skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -692,6 +692,7 @@ An open standard (Anthropic, Dec 2025) for packaging expertise into portable dir
 | [anthropics/skills](https://github.com/anthropics/skills) | Official collection + spec (`/spec/agent-skills-spec.md`) ![](https://img.shields.io/github/stars/anthropics/skills?style=flat-square) |
 | [VoltAgent/awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills) | 1000+ community skills, works across all major platforms |
 | [vercel-labs/agent-skills](https://github.com/vercel-labs/agent-skills) | Vercel's official skills |
+| [nowork-studio/NotFair](https://github.com/nowork-studio/NotFair) | Marketing skills — [SEO/GEO](https://github.com/nowork-studio/NotFair/tree/main/seo), [Google Ads](https://github.com/nowork-studio/NotFair/tree/main/google-ads), [Meta Ads](https://github.com/nowork-studio/NotFair/tree/main/meta-ads); connects to live data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP ![](https://img.shields.io/github/stars/nowork-studio/NotFair?style=flat-square) |
 | [Agent Skills Docs — Anthropic](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview) | Official docs & spec |
 | [Equipping Agents for the Real World — Anthropic](https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills) | Announcement post |
 | [Skills vs MCP — LlamaIndex](https://www.llamaindex.ai/blog/skills-vs-mcp-tools-for-agents-when-to-use-what) | When to use which |


### PR DESCRIPTION
Hi, and thanks for maintaining this list — the Agent Skills table was the perfect home for this.

I'd like to suggest **[NotFair](https://github.com/nowork-studio/NotFair)** (MIT, ~2.9k stars) for the **Agent Skills** section. It's an open-source collection of Claude Code skills focused on marketing work: SEO and GEO (site analysis, keyword research, meta tags, schema markup, content writing), Google Ads (audits, wasted-spend detection, search-term cleanup, bid/keyword management), and Meta Ads (ROAS, creative fatigue, audience overlap).

What makes it a good fit alongside the existing community collections like VoltAgent/awesome-agent-skills is that it pairs the skills with live data: the skills connect through the Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP, so it's a concrete example of the Skills + MCP pattern this section already discusses.

I kept the entry to a single row matching the table's style. Happy to reword, move it, or trim the description however you prefer.